### PR TITLE
Hacky fix to force valid date ranges

### DIFF
--- a/_data/dashboard.yml
+++ b/_data/dashboard.yml
@@ -4,7 +4,7 @@ ukgovcats:
 
   metrics:
 
-    - metric: Active Gov Cats
+    - metric: active-gov-cats
       colours:
         text: white
         box: blue
@@ -16,7 +16,7 @@ ukgovcats:
       height: 1
       width: 1
 
-    - metric: Total Sw1 Cats
+    - metric: total-sw1-cats
       colours:
         text: white
         box: khaki
@@ -28,7 +28,7 @@ ukgovcats:
       height: 1
       width: 1
 
-    - metric: Schrodingers Gov Cats
+    - metric: schrodingers-gov-cats
       colours:
         text: white
         box: orange
@@ -40,7 +40,7 @@ ukgovcats:
       height: 1
       width: 1
 
-    - metric: Total Gov Cats
+    - metric: total-gov-cats
       colours:
         text: white
         box: burgundy
@@ -52,7 +52,7 @@ ukgovcats:
       height: 1
       width: 1
 
-    - metric: Total Uk Cats
+    - metric: total-uk-cats
       colours:
         text: white
         box: green
@@ -64,7 +64,7 @@ ukgovcats:
       height: 1
       width: 1
 
-    - metric: Total Uk government departments
+    - metric: total-uk-government-departments
       colours:
         text: white
         box: gold

--- a/_data/dashboard.yml
+++ b/_data/dashboard.yml
@@ -9,6 +9,8 @@ ukgovcats:
         text: white
         box: blue
       type: number
+      from: '*'
+      to: '*'
       row: 1
       col: 1
       height: 1
@@ -19,6 +21,8 @@ ukgovcats:
         text: white
         box: khaki
       type: number
+      from: '*'
+      to: '*'
       row: 1
       col: 2
       height: 1
@@ -29,6 +33,8 @@ ukgovcats:
         text: white
         box: orange
       type: number
+      from: '*'
+      to: '*'
       row: 2
       col: 3
       height: 1
@@ -39,6 +45,8 @@ ukgovcats:
         text: white
         box: burgundy
       type: number
+      from: '*'
+      to: '*'
       row: 2
       col: 2
       height: 1
@@ -49,6 +57,8 @@ ukgovcats:
         text: white
         box: green
       type: number
+      from: '*'
+      to: '*'
       row: 1
       col: 3
       height: 1
@@ -59,6 +69,8 @@ ukgovcats:
         text: white
         box: gold
       type: number
+      from: '*'
+      to: '*'
       row: 2
       col: 1
       height: 1


### PR DESCRIPTION
The dashboard looks a bit broken currently:
![screen shot 2016-11-25 at 08 54 11](https://cloud.githubusercontent.com/assets/464193/20621509/b150e392-b2f6-11e6-83a4-19ff85d6007b.png)

I think it’s because default bothan behaviour is a bit weird for single number data that isn’t updated very often.

This breaks quite dramatically:
https://catdashboard.herokuapp.com/metrics/active-gov-cats?layout=bare&boxcolour=9bcbea&textcolour=ffffff&font_size=9vh&type=number&pie_colours=

That’s because it defaults to:
https://catdashboard.herokuapp.com/metrics/active-gov-cats/P1M/*?boxcolour=9bcbea&font_size=9vh&layout=bare&pie_colours=&textcolour=ffffff&type=number

Whereas we’d probably prefer that it defaulted to `latest` or:
https://catdashboard.herokuapp.com/metrics/active-gov-cats/*/*?boxcolour=9bcbea&font_size=9vh&layout=bare&pie_colours=&textcolour=ffffff&type=number

This fixes that (and slugifies stuff, because the auto-slugify seems to go wrong).